### PR TITLE
Fixed issue with `psr7` versions that could prevent installing this package in a naked flarum instance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">= 7.4",
         "ext-json": "*",
         "guzzlehttp/guzzle": "7.3.*",
-        "guzzlehttp/psr7": "1.8.*",
+        "guzzlehttp/psr7": "~1.1 || ^2.0",
         "illuminate/support": "8.*",
         "vlucas/phpdotenv": "^5.2",
         "psr/cache": "^1.0",


### PR DESCRIPTION
When running `composer install` for a naked flarum installation and then running `composer require extiverse/mercury v0.1.3` (mercury uses `extiverse/api-client`) the following error comes : 

```
#8 5.604 Your requirements could not be resolved to an installable set of packages.
#8 5.604
#8 5.604   Problem 1
#8 5.604     - extiverse/api-client[0.2.1, ..., 0.2.3] require guzzlehttp/psr7 1.8.* -> found guzzlehttp/psr7[1.8.0, 1.8.1, 1.8.2, 1.8.3] but the package is fixed to 2.0.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
#8 5.604     - extiverse/mercury 0.1.3 requires extiverse/api-client ^0.2.1 -> satisfiable by extiverse/api-client[0.2.1, 0.2.2, 0.2.3].
#8 5.604     - Root composer.json requires extiverse/mercury v0.1.3 -> satisfiable by extiverse/mercury[0.1.3].
```

This change should fix that issue.
